### PR TITLE
feat: add Module Site Deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Gatsby Publish
+name: Publish ModuleSIte on gh-pages
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Gatsby Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2
+        with:
+          access-token: ${{ secrets.MODULESITE_DEPLOY_TOKEN }}
+          deploy-branch: deploy
+          gatsby-args: --prefix-paths

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,24 @@
-name: Publish ModuleSIte on gh-pages
+name: Publish ModuleSite on gh-pages
 
 on:
+  # Trigger the workflow on push only for master branch
   push:
     branches:
       - master
 
 jobs:
+  # Trigger job i.e. build and run on the latest version of ubuntu
   build:
     runs-on: ubuntu-latest
+    of github and for building and release ModuleSite
     steps:
+      # Template that allows deploy.yml file to access github project when running on its own environment
       - uses: actions/checkout@v2
+      # Template to build and release ModuleSite
       - uses: enriikke/gatsby-gh-pages-action@v2.2.0
         with:
           access-token: ${{ secrets.MODULESITE_DEPLOY_TOKEN }}
+          # Output after building the ModuleSite will be pushed on deploy branch
           deploy-branch: deploy
+          # Additional arguments that get passed to gatsby build 
           gatsby-args: --prefix-paths

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.MODULESITE_DEPLOY_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: enriikke/gatsby-gh-pages-action@v2
+      - uses: enriikke/gatsby-gh-pages-action@v2.2.0
         with:
           access-token: ${{ secrets.MODULESITE_DEPLOY_TOKEN }}
           deploy-branch: deploy

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -1,4 +1,4 @@
-<h1 align="center"> ModuleSite Deployment </h1>
+# ModuleSite Deployment
 
 [ModuleSite](https://github.com/MovingBlocks/ModuleSite) uses a [Github Actions](https://github.com/features/actions) to automate the deployment process.On every push Github actions are triggered and ModuleSite is build and it is deployed on
 [Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages)

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -1,0 +1,37 @@
+## What are Github Action?
+
+[Github Actions](https://github.com/features/actions) is a service offered by github that allow you to automate task that commonly happen withing software development.The service is event driven that means, whenever an event is triggered you are able to execute a set of instruction that you define so whenever you define, push a change to remote branch or open up a PR, create issue
+those are all considered events, anything you can do with a repository inside the github website.You can probably programmatically trigger those events.
+
+## What is Continous Deployment?
+
+[Continous Deployment](https://en.wikipedia.org/wiki/Continuous_deployment) is the automated process of releasing any changes made to a code base, whenever a programmer pushes any changes to their code base, continous deployment
+take those changes build them and release it again.
+
+## GitHub Pages
+
+[Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages) is static site hosting service, which lets you turn you github repository into website to showcase your documentaion, projects, portfolio etc.No databases to steup
+and no servers to configure. It takes HTML, CSS, and JavaScript files straight from a repository on GitHub, optionally runs the files through a build process, and publishes a website
+
+## ModuleSite Deployment
+
+[ModuleSite](https://github.com/MovingBlocks/ModuleSite) uses a Github actions to automate the deployment process on github pages.On every push Github actions are triggered and the action runs a [Gatsby publish
+template](https://github.com/marketplace/actions/gatsby-publish).This template provides fews options and configurations which is need to deploy the ModuleSite. `.github\workflows` directory in ModuleSite which contains
+deployment pipeline `deploy.yml` .
+
+The first part of pipeline includes the name of our Github action and the event, which will decide when our job will trigger and on which branch.In our case it is master.
+The Second half of pipeline contains on which environment our job will trigger and the steps which includes templates. we have used two templates `actions/checkout`
+which allows our `deploy.yml` file to have access to our ModuleSite and another template is our gatsby publish template which will help us to build our gatsby ModuleSite
+and realease it.Their are some argument which is required by the gatsby publish template in order to work.The first argument is access token which will allow the template
+to push changes when it is done building and second argument is deploy branch.In our case branch name is `deploy`
+
+Above we saw what is our workflow for Deployment. Now let's understand how Gatsby Publish template works behind the scenes
+During every push the gatsby template runs a `gatsby build` command which outputs the `public` directory and the template initilize a new repository inside
+the public directoy, commit it and push it into the deploy branch mentioned above
+
+### CNAME
+
+A Canonical Name or [CNAME](https://en.wikipedia.org/wiki/CNAME_record) record is a type of DNS record that maps an alias name to a true or canonical domain name.
+CNAME records are typically used to map a subdomain
+such as www or mail to the domain hosting that subdomain's content.This will be file inside our ModuleSite which contain our domain name, during ModuleSite building
+process gatsby template copies the CNAME file into public directory and Github pages will automatically detect the domain name host our ModuleSite

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -26,7 +26,7 @@ and realease it.Their are some argument which is required by the gatsby publish 
 to push changes when it is done building and second argument is deploy branch.In our case branch name is `deploy`
 
 Above we saw what is our workflow for Deployment. Now let's understand how Gatsby Publish template works behind the scenes
-During every push the gatsby template runs a `gatsby build` command which outputs the `public` directory and the template initilize a new repository inside
+During every push the gatsby template runs a `gatsby build` command which outputs the `public` directory and the template initialize a new repository inside
 the public directoy, commit it and push it into the deploy branch mentioned above
 
 ### CNAME

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -1,24 +1,26 @@
 # ModuleSite Deployment
 
-[ModuleSite](https://github.com/MovingBlocks/ModuleSite) uses a [Github Actions](https://github.com/features/actions) to automate the deployment process.On every push Github actions are triggered and ModuleSite is build and it is deployed on
-[Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages)
+[ModuleSite](https://github.com/MovingBlocks/ModuleSite) uses a [Github Action](https://github.com/features/actions) to automate the deployment process. On every push to `master`, the GitHub action is triggered, builds the ModuleSite and deploys it on
+[GitHub pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages)
 
-## Requirements and Working
+## Requirements
 
-<b>Gatsby Publish:</b> Github Action to build and deploy Gatsby site on Github pages.More about [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish)
+**[Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish):** Github Action to build and deploy Gatsby site on Github pages.
 
-Everytime the Github actions are triggered it executes `gatsby build` at the root of repository and deploy it to github pages.
+## Working
+
+Everytime the GitHub action is triggered, it executes `gatsby build` at the root of the repository and deploys it to GitHub pages.
 You can find our Github action workflow in `.github\workflow`
 
 Before using Action their are some configuration options that are provide by Gatsby Publish
 
-- <b>access-token: </b>
+- **access-token:**
   A GitHub Personal Access Token with access of pushing and creating pull request.This is require to push builds after building the Site.The access token should be stored as secret text in the repository settings
 
-- <b>deploy-branch: </b>
+- **deploy-branch:**
   This will be branch where all the outputs after executing `gatsby build` will be push. This includes static files that were generated duing build process
 
-- <b>gatsby-args: </b>
+- **gatsby-args:**
   Additional arguments that get passed to gatsby build. See the [Gatsby documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) for a list of allowed options. Provided as an input. Defaults to nothing.
 
 The above configuration options were used by ModuleSite.For more information about configuration visit Gatsby Publish

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -12,17 +12,17 @@
 Everytime the GitHub action is triggered, it executes `gatsby build` at the root of the repository and deploys it to GitHub pages.
 You can find our Github action workflow in `.github\workflow`
 
-Before using Action their are some configuration options that are provide by Gatsby Publish
+For using the GitHub action, Gatsby Publish provides some configuration options:
 
 - **access-token:**
-  A GitHub Personal Access Token with access of pushing and creating pull request.This is require to push builds after building the Site.The access token should be stored as secret text in the repository settings
+  A GitHub Personal Access Token with access for pushing and creating pull requests. This is required to push builds after building the Site. The access token should be stored as a secret in the repository settings.
 
 - **deploy-branch:**
-  This will be branch where all the outputs after executing `gatsby build` will be push. This includes static files that were generated duing build process
+  This is the branch to which all the outputs after executing `gatsby build` will be pushed. This includes static files that were generated during build process.
 
 - **gatsby-args:**
   Additional arguments that get passed to gatsby build. See the [Gatsby documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) for a list of allowed options. Provided as an input. Defaults to nothing.
 
-The above configuration options were used by ModuleSite.For more information about configuration visit Gatsby Publish
+The above configuration options are used by the ModuleSite. For more information about the configuration visit [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish).
 
-> **⚠️ NOTE:** The Gatsby code is on root directory so after build process `./public` directory is generated.Gatsby do not allow to edit or customize the public directory, so we have to build code everytime when their is any changes to Gatsby code.Gatsby automatically provides a build script on `Package.json` which is required by the Action to execute the build process
+> **⚠️ NOTE:** The Gatsby code is located in the root directory. After the build process the `./public` directory is generated. Gatsby does not allow to edit or customize the public directory, so we have to build code every time the Gatsby code changes. Gatsby automatically provides a build script on `Package.json` which is required by the GitHub action to execute the build process.

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -21,7 +21,7 @@ For using the GitHub action, Gatsby Publish provides some configuration options:
   This is the branch to which all the outputs after executing `gatsby build` will be pushed. This includes static files that were generated during build process.
 
 - **gatsby-args:**
-  Additional arguments that get passed to gatsby build. See the [Gatsby documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) for a list of allowed options. Provided as an input. Defaults to nothing.
+  Additional arguments that get passed to `gatsby build`. See the [Gatsby documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) for a list of allowed options. Provided as an input. Defaults to nothing.
 
 The above configuration options are used by the ModuleSite. For more information about the configuration visit [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish).
 

--- a/docs/project-deployment.md
+++ b/docs/project-deployment.md
@@ -1,37 +1,26 @@
-## What are Github Action?
+<h1 align="center"> ModuleSite Deployment </h1>
 
-[Github Actions](https://github.com/features/actions) is a service offered by github that allow you to automate task that commonly happen withing software development.The service is event driven that means, whenever an event is triggered you are able to execute a set of instruction that you define so whenever you define, push a change to remote branch or open up a PR, create issue
-those are all considered events, anything you can do with a repository inside the github website.You can probably programmatically trigger those events.
+[ModuleSite](https://github.com/MovingBlocks/ModuleSite) uses a [Github Actions](https://github.com/features/actions) to automate the deployment process.On every push Github actions are triggered and ModuleSite is build and it is deployed on
+[Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages)
 
-## What is Continous Deployment?
+## Requirements and Working
 
-[Continous Deployment](https://en.wikipedia.org/wiki/Continuous_deployment) is the automated process of releasing any changes made to a code base, whenever a programmer pushes any changes to their code base, continous deployment
-take those changes build them and release it again.
+<b>Gatsby Publish:</b> Github Action to build and deploy Gatsby site on Github pages.More about [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish)
 
-## GitHub Pages
+Everytime the Github actions are triggered it executes `gatsby build` at the root of repository and deploy it to github pages.
+You can find our Github action workflow in `.github\workflow`
 
-[Github pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages) is static site hosting service, which lets you turn you github repository into website to showcase your documentaion, projects, portfolio etc.No databases to steup
-and no servers to configure. It takes HTML, CSS, and JavaScript files straight from a repository on GitHub, optionally runs the files through a build process, and publishes a website
+Before using Action their are some configuration options that are provide by Gatsby Publish
 
-## ModuleSite Deployment
+- <b>access-token: </b>
+  A GitHub Personal Access Token with access of pushing and creating pull request.This is require to push builds after building the Site.The access token should be stored as secret text in the repository settings
 
-[ModuleSite](https://github.com/MovingBlocks/ModuleSite) uses a Github actions to automate the deployment process on github pages.On every push Github actions are triggered and the action runs a [Gatsby publish
-template](https://github.com/marketplace/actions/gatsby-publish).This template provides fews options and configurations which is need to deploy the ModuleSite. `.github\workflows` directory in ModuleSite which contains
-deployment pipeline `deploy.yml` .
+- <b>deploy-branch: </b>
+  This will be branch where all the outputs after executing `gatsby build` will be push. This includes static files that were generated duing build process
 
-The first part of pipeline includes the name of our Github action and the event, which will decide when our job will trigger and on which branch.In our case it is master.
-The Second half of pipeline contains on which environment our job will trigger and the steps which includes templates. we have used two templates `actions/checkout`
-which allows our `deploy.yml` file to have access to our ModuleSite and another template is our gatsby publish template which will help us to build our gatsby ModuleSite
-and realease it.Their are some argument which is required by the gatsby publish template in order to work.The first argument is access token which will allow the template
-to push changes when it is done building and second argument is deploy branch.In our case branch name is `deploy`
+- <b>gatsby-args: </b>
+  Additional arguments that get passed to gatsby build. See the [Gatsby documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) for a list of allowed options. Provided as an input. Defaults to nothing.
 
-Above we saw what is our workflow for Deployment. Now let's understand how Gatsby Publish template works behind the scenes
-During every push the gatsby template runs a `gatsby build` command which outputs the `public` directory and the template initialize a new repository inside
-the public directoy, commit it and push it into the deploy branch mentioned above
+The above configuration options were used by ModuleSite.For more information about configuration visit Gatsby Publish
 
-### CNAME
-
-A Canonical Name or [CNAME](https://en.wikipedia.org/wiki/CNAME_record) record is a type of DNS record that maps an alias name to a true or canonical domain name.
-CNAME records are typically used to map a subdomain
-such as www or mail to the domain hosting that subdomain's content.This will be file inside our ModuleSite which contain our domain name, during ModuleSite building
-process gatsby template copies the CNAME file into public directory and Github pages will automatically detect the domain name host our ModuleSite
+> **⚠️ NOTE:** The Gatsby code is on root directory so after build process `./public` directory is generated.Gatsby do not allow to edit or customize the public directory, so we have to build code everytime when their is any changes to Gatsby code.Gatsby automatically provides a build script on `Package.json` which is required by the Action to execute the build process

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ const urljoin = require("url-join");
 const config = require("./data/SiteConfig");
 
 module.exports = {
-  pathPrefix: config.pathPrefix === "" ? "/" : config.pathPrefix,
+  pathPrefix: config.pathPrefix === "" ? "/ModuleSite" : config.pathPrefix,
   siteMetadata: {
     siteUrl: urljoin(config.siteUrl, config.pathPrefix),
     rssMetadata: {


### PR DESCRIPTION
This PR includes the Github Actions Workflow of ModuleSite Deployment which uses [Gatsby publish](https://github.com/marketplace/actions/gatsby-publish) template to Deploy  ModuleSite  on gh-pages

Closes #48 