### PR TITLE
fix: multiple tags issue

### DIFF
--- a/blog/2017-06-14/index.md
+++ b/blog/2017-06-14/index.md
@@ -6,7 +6,7 @@ description: "If you have visited our website before you might notice something 
 author: "Scott Moses Sunarto"
 ddate: "June 14th, 2017"
 date: "2017-06-14"
-tags: "Update"
+tags: ["Update"]
 ---
 ### Heya Terasologist!
 

--- a/blog/2017-07-14/index.md
+++ b/blog/2017-07-14/index.md
@@ -7,7 +7,7 @@ that all ten students have passed the first evaluation."
 author: "skaldarnar"
 ddate: "July 14th, 2017"
 date: "2017-07-14"
-tags: "GSoC"
+tags: ["GSoC"]
 ---
 
 The first hurdle of [Google Summer of Code][GSOC] is already over for our students, so it's about time to happily announce

--- a/blog/2017-09-17/index.md
+++ b/blog/2017-09-17/index.md
@@ -6,7 +6,7 @@ description: "It all started with one hot sleepless night in October. I stumbled
 author: "nihal111"
 ddate: "September 09th, 2017"
 date: "2017-09-17"
-tags: "Project"
+tags: ["Project"]
 ---
 
 It all started with one hot sleepless night in October. I stumbled upon the Terasology project and hopped on to the org's IRC. It took me a while to get everything running from source. After I played around for a bit, I had a glance at the issue tracker. Conveniently, I found a couple of bite-sized bugs and I sent out PR fixes by the next morning. From there to a GCI mentor last winter and a GSoC student past summer, it has been a hell of a ride.

--- a/blog/2017-11-28/index.md
+++ b/blog/2017-11-28/index.md
@@ -6,7 +6,7 @@ description: "MovingBlocks is once again participating in Google Code-In this ye
 author: "Thorbjørn Lindeijer"
 ddate: "November 28th, 2017"
 date: "2017-11-28"
-tags: "Update"
+tags: ["Update"]
 ---
 
 MovingBlocks is once again participating in [Google Code-In](https://codein.withgoogle.com/) this year.

--- a/blog/2018-09-02/index.md
+++ b/blog/2018-09-02/index.md
@@ -6,7 +6,7 @@ description: "For Google Summer of Code (GSOC) 2018 we had 9 awesome students wo
 author: "Cervator"
 ddate: "September 02nd, 2018"
 date: "2018-09-02"
-tags: "GSoC"
+tags: ["GSoC"]
 ---
 
 For Google Summer of Code (GSOC) 2018 we had 9 awesome students working on a mix of content tasks and other improvements.

--- a/blog/2019-05-29/index.md
+++ b/blog/2019-05-29/index.md
@@ -6,7 +6,7 @@ description: "It’s that time of the year again - Google Summer of Code (GSOC) 
 author: "Niruandaleth & Skaldarnar"
 ddate: "May 29th, 2019"
 date: "2019-05-29"
-tags: "GSoC"
+tags: ["GSoC"]
 ---
 
 It’s that time of the year again - Google Summer of Code (GSOC) is ahead of us.

--- a/blog/2019-09-27/index.md
+++ b/blog/2019-09-27/index.md
@@ -6,7 +6,7 @@ description: "Another summer full of coding and fun is finally over, and now it'
 author: "Niruandaleth & Skaldarnar"
 ddate: "Sept 27th, 2019"
 date: "2019-09-27"
-tags: "GSoC"
+tags: ["GSoC"]
 ---
 
 A few months ago, we introduced [this year's Google Summer of Code students and their projects](/blog/gsoc-2019-an-overview). Now that the summer is over, it's time to summarize what has happened. But first of all: we are very happy to thank all our nine students for their contributions to [The Terasology Foundation], and we want to congratulate them for successfully finishing a Summer of Code!

--- a/blog/2019-10-28/index.md
+++ b/blog/2019-10-28/index.md
@@ -8,7 +8,7 @@ description: " It has been a fun week for a handful of our contributors in Munic
 author: "Niruandaleth & Skaldarnar"
 ddate: "Oct 28th, 2019"
 date: "2019-10-28"
-tags: "GSoC"
+tags: ["GSoC"]
 ---
 
 _It has been a fun week for a handful of our contributors in Munich, Germany. We took the opportunity of the Google

--- a/blog/2020-01-25/index.md
+++ b/blog/2020-01-25/index.md
@@ -6,7 +6,7 @@ description: "A summary of what has been going on in the past week of Terasology
 author: "Jordan H. (Qwertygiy)"
 ddate: "Jan 25th, 2020"
 date: "2020-01-25"
-tags: "TeraSaturday"
+tags: ["TeraSaturday"]
 ---
 
 _And now for something completely different: **TeraSaturday**, a weekly update post about all the neat stuff that has been going on in

--- a/blog/2020-02-01/index.md
+++ b/blog/2020-02-01/index.md
@@ -6,7 +6,7 @@ description: "A summary of what has been going on in the past week of Terasology
 author: "Jordan H. (Qwertygiy)"
 ddate: "Feb 1st, 2020"
 date: "2020-02-01"
-tags: "TeraSaturday"
+tags: ["TeraSaturday"]
 ---
 
 _Welcome to the sequel edition of **TeraSaturday**, a weekly update post about all the neat stuff that has been going on in

--- a/blog/2020-05-30-terasaturday-3/index.md
+++ b/blog/2020-05-30-terasaturday-3/index.md
@@ -6,7 +6,7 @@ description: "An exploration of recent events in Terasology development."
 author: "Jordan H. (Qwertygiy)"
 ddate: "May 30th, 2020"
 date: "2020-05-30"
-tags: "TeraSaturday"
+tags: ["TeraSaturday"]
 ---
 
 _Welcome to the return of TeraSaturday, a not-so-weekly update post about all the neat stuff that has been going on in 

--- a/blog/2020-05-30/index.md
+++ b/blog/2020-05-30/index.md
@@ -8,7 +8,7 @@ description: "5th year anniversary for Terasology participating in Google Summer
 author: "Niruandaleth & Skaldarnar"
 ddate: "May 30th, 2020"
 date: "2020-05-30"
-tags: "GSOC"
+tags: ["GSOC"]
 ---
 
 This year is the 5th year anniversary for Terasology participating in the Google Summer of Code (GSOC) 🎉

--- a/blog/2020-06-06/index.md
+++ b/blog/2020-06-06/index.md
@@ -6,7 +6,7 @@ description: "An exploration of recent events in Terasology development"
 author: "Jordan H. (Qwertygiy)"
 ddate: "June 6th, 2020"
 date: "2020-06-06"
-tags: "TeraSaturday"
+tags: ["TeraSaturday"]
 ---
 
 _Welcome to the return of TeraSaturday, a not-so-weekly update post about all the neat stuff that has been going on in 

--- a/blog/2020-07-19/index.md
+++ b/blog/2020-07-19/index.md
@@ -8,7 +8,7 @@ description: "Students are mid-way through Google Summer of Code 2020 🎉
 author: "Niruandaleth & Skaldarnar"
 ddate: "July 19th, 2020"
 date: "2020-07-19"
-tags: "GSOC"
+tags: ["GSOC"]
 ---
 
 In our 5th year participating in the Google Summer of Code (GSOC), we [welcomed](gsoc-2020-an-overview) six students to our community that joined efforts with mentors and other contributors to make Terasology even more awesome!

--- a/blog/2020-09-27/index.md
+++ b/blog/2020-09-27/index.md
@@ -8,7 +8,7 @@ description: "Google Summer of Code 2020 is over 🏁
 author: "Niruandaleth"
 ddate: "Sept 27th, 2020"
 date: "2020-09-27"
-tags: "GSOC"
+tags: ["GSOC"]
 ---
 
 Our 5th year anniversary of inviting Google Summer of Code (GSOC) students into our community is over.

--- a/blog/2020-11-21/index.md
+++ b/blog/2020-11-21/index.md
@@ -6,7 +6,7 @@ description: "An exploration of recent events in Terasology development."
 author: "Skaldarnar"
 ddate: "Dec 21st, 2020"
 date: "2020-11-21"
-tags: "TeraSaturday"
+tags: ["TeraSaturday"]
 ---
 
 _Welcome to the return of TeraSaturday, a not-so-weekly update post about all the neat stuff that has been going on in

--- a/modules/Gooey Example/index.md
+++ b/modules/Gooey Example/index.md
@@ -4,7 +4,7 @@ title: "Gooey Example"
 cover: "../../static/logos/cover.jpg"
 date: "01/01/2017"
 category: "logic"
-tags: "Logic"
+tags: ["Logic"]
 ---
 
 ![header](https://i.imgur.com/Bo7RZQv.png)

--- a/modules/Gooey Example/index.md
+++ b/modules/Gooey Example/index.md
@@ -4,7 +4,7 @@ title: "Gooey Example"
 cover: "../../static/logos/cover.jpg"
 date: "01/01/2017"
 category: "logic"
-tags: ["Logic"]
+tags: ["Logic","Augment"]
 ---
 
 ![header](https://i.imgur.com/Bo7RZQv.png)

--- a/modules/farming/index.md
+++ b/modules/farming/index.md
@@ -4,7 +4,7 @@ title: "Farming"
 cover: "../../static/logos/cover.jpg"
 date: "01/01/2017"
 category: "tech"
-tags: "Logic"
+tags: ["Logic"]
 ---
 
 ![header](title.png)

--- a/modules/farming/index.md
+++ b/modules/farming/index.md
@@ -4,7 +4,7 @@ title: "Farming"
 cover: "../../static/logos/cover.jpg"
 date: "01/01/2017"
 category: "tech"
-tags: ["Logic"]
+tags: ["Logic","Asset","Library"]
 ---
 
 ![header](title.png)

--- a/modules/gooey-defence/index.md
+++ b/modules/gooey-defence/index.md
@@ -4,7 +4,7 @@ title: "Gooey Defence"
 cover: "../../static/logos/cover.jpg"
 date: "01/01/2017"
 category: "tech"
-tags: "Gameplay Template"
+tags: ["Gameplay Template"]
 ---
 This module serves as the main module for the Gooey's Defence Gameplay Template.  
 It currently is undergoing active development and thus is not at a public release stage.

--- a/modules/light-and-shadow/index.md
+++ b/modules/light-and-shadow/index.md
@@ -4,7 +4,7 @@ title: "Light And Shadow"
 cover: "../../static/logos/cover.jpg"
 date: "01/01/2017"
 category: "tech"
-tags: "Gameplay Template"
+tags: ["Gameplay Template"]
 ---
 
 Light & Shadow is an experimental game type set in a quirky Alice in Wonderland inspired setting.

--- a/src/components/Cards/Cards.jsx
+++ b/src/components/Cards/Cards.jsx
@@ -4,45 +4,30 @@ import { Row, Col, Badge } from "reactstrap";
 import { GatsbyImage } from "gatsby-plugin-image";
 
 const Cards = ({ title, cover, tags, excerpt, path }) => {
-  
-  console.log(tags.length)
   let totalTags = [];
-  if (tags.length >=1) {
-    for (let tag = 0; tag <=1; tag++) {
+  if (tags.length >= 1) {
+    for (let tag = 0; tag <= 1; tag++) {
       totalTags.push(tags[tag]);
     }
   }
-   
-  let tagCount=tags.length-2
-  
-
- 
-   
+  let tagCount = tags.length - 2;
   return (
-        <Col className="ml-4 mr-4 mt-2 mb-2 " lg="3" md="8" sm="12">
+    <Col className="ml-4 mr-4 mt-2 mb-2 " lg="3" md="8" sm="12">
       <Row className="row_shadow h-100">
         <Col lg="12" md="12" className="p-0">
           <div className="card-img search-cards">
             <GatsbyImage image={cover.gatsbyImageData} />
           </div>
-          < div className="d-flex">
-          <div className="md-tag mt-3 ml-3">
-           {
-             totalTags.map((tag)=>{
-               return (
-                <Badge className="mr-2">
-                {tag}
-              </Badge>
-               )
-               
-             }) 
-
-           }
-            
-          </div> 
-
-          <span className="card-people ml-2 mt-4 mr-4  h4">{tagCount>0?("+"+`${tagCount}`+ " more"):("")} </span>
-        </div>
+          <div className="d-flex">
+            <div className="md-tag mt-3 ml-3">
+              {totalTags.map((tag) => {
+                return <Badge className="mr-2">{tag}</Badge>;
+              })}
+            </div>
+            <span className="card-people ml-2 mt-4 mr-4  h4">
+              {tagCount > 0 ? "+" + `${tagCount}` + " more" : ""}{" "}
+            </span>
+          </div>
         </Col>
         <div className="d-flex flex-column ml-3">
           <h5 className="mt-1">{title}</h5>

--- a/src/components/Cards/Cards.jsx
+++ b/src/components/Cards/Cards.jsx
@@ -4,12 +4,6 @@ import { Row, Col, Badge } from "reactstrap";
 import { GatsbyImage } from "gatsby-plugin-image";
 
 const Cards = ({ title, cover, tags, excerpt, path }) => {
-  let totalTags = [];
-  if (tags.length >= 1) {
-    for (let tag = 0; tag <= 1; tag++) {
-      totalTags.push(tags[tag]);
-    }
-  }
   let tagCount = tags.length - 2;
   return (
     <Col className="ml-4 mr-4 mt-2 mb-2 " lg="3" md="8" sm="12">
@@ -20,7 +14,7 @@ const Cards = ({ title, cover, tags, excerpt, path }) => {
           </div>
           <div className="d-flex">
             <div className="md-tag mt-3 ml-3">
-              {totalTags.map((tag) => {
+              {tags.slice(0, 2).map((tag) => {
                 return <Badge className="mr-2">{tag}</Badge>;
               })}
             </div>

--- a/src/components/Cards/Cards.jsx
+++ b/src/components/Cards/Cards.jsx
@@ -4,16 +4,45 @@ import { Row, Col, Badge } from "reactstrap";
 import { GatsbyImage } from "gatsby-plugin-image";
 
 const Cards = ({ title, cover, tags, excerpt, path }) => {
+  
+  console.log(tags.length)
+  let totalTags = [];
+  if (tags.length >=1) {
+    for (let tag = 0; tag <=1; tag++) {
+      totalTags.push(tags[tag]);
+    }
+  }
+   
+  let tagCount=tags.length-2
+  
+
+ 
+   
   return (
-    <Col className="ml-4 mr-4 mt-2 mb-2 " lg="3" md="8" sm="12">
+        <Col className="ml-4 mr-4 mt-2 mb-2 " lg="3" md="8" sm="12">
       <Row className="row_shadow h-100">
         <Col lg="12" md="12" className="p-0">
           <div className="card-img search-cards">
             <GatsbyImage image={cover.gatsbyImageData} />
           </div>
+          < div className="d-flex">
           <div className="md-tag mt-3 ml-3">
-            <Badge>{tags}</Badge>
-          </div>
+           {
+             totalTags.map((tag)=>{
+               return (
+                <Badge className="mr-2">
+                {tag}
+              </Badge>
+               )
+               
+             }) 
+
+           }
+            
+          </div> 
+
+          <span className="card-people ml-2 mt-4 mr-4  h4">{tagCount>0?("+"+`${tagCount}`+ " more"):("")} </span>
+        </div>
         </Col>
         <div className="d-flex flex-column ml-3">
           <h5 className="mt-1">{title}</h5>

--- a/src/components/PostTags/PostTags.jsx
+++ b/src/components/PostTags/PostTags.jsx
@@ -5,11 +5,12 @@ import { Button } from "reactstrap";
 
 const PostTags = ({ tags, type }) => (
   <div className="post-tag-container">
+    {console.log(tags)}
     {tags && (
       <Link
         key={tags}
         style={{ textDecoration: "none" }}
-        to={`/${type}/?keywords=&filter=${_.kebabCase(tags.split(" ")[0])}`}
+        to={`/${type}/?keywords=&filter=${_.kebabCase(tags)}`}
       >
         <Button color="primary" size="lg">
           {tags}

--- a/src/components/PostTags/PostTags.jsx
+++ b/src/components/PostTags/PostTags.jsx
@@ -5,16 +5,18 @@ import { Button } from "reactstrap";
 
 const PostTags = ({ tags, type }) => (
   <div className="post-tag-container">
-    {tags && 
-        <Link
-          key={tags}
-          style={{ textDecoration: "none" }}
-          to={`/${type}/?keywords=&filter=${_.kebabCase(tags.split(" ")[0])}`}
-        >
-          <Button color="primary" size="lg">{tags}</Button>
-        </Link>
-      }
+    {tags && (
+      <Link
+        key={tags}
+        style={{ textDecoration: "none" }}
+        to={`/${type}/?keywords=&filter=${_.kebabCase(tags.split(" ")[0])}`}
+      >
+        <Button color="primary" size="lg">
+          {tags}
+        </Button>
+      </Link>
+    )}
   </div>
 );
 
-export default PostTags
+export default PostTags;

--- a/src/components/PostTags/PostTags.jsx
+++ b/src/components/PostTags/PostTags.jsx
@@ -5,7 +5,6 @@ import { Button } from "reactstrap";
 
 const PostTags = ({ tags, type }) => (
   <div className="post-tag-container">
-    {console.log(tags)}
     {tags && (
       <Link
         key={tags}

--- a/src/templates/blog.jsx
+++ b/src/templates/blog.jsx
@@ -17,7 +17,7 @@ const blog = (
   props
 ) => {
   const postEdges = data.allMarkdownRemark.edges;
-  const DATA = blogList;
+  const blogData = blogList;
 
   const prefix = "/blog/";
   const isFirst = blogCurrentPage === 1;
@@ -44,14 +44,13 @@ const blog = (
   useEffect(() => {
     if (searchQuery || filterTag) {
       setResults(
-        DATA.filter((blog) => {
+        blogData.filter((blog) => {
           const searchRgx = new RegExp(escapeRegExp(searchQuery), "gi");
           const tagRgx = new RegExp(escapeRegExp(filterTag), "gi");
-          let matchedTag=[]
-          blog.tags.map(tag=>{
-            matchedTag.push(tag.match(tagRgx))
-          })
-          return matchedTag.toString().match(tagRgx) && blog.title.match(searchRgx);
+          const matchedTag = blog.tags.filter(tag => tag != null).map(t => t.match(tagRgx))
+          return (
+            matchedTag.toString().match(tagRgx) && blog.title.match(searchRgx)
+          );
         })
       );
       setIsShown(true);

--- a/src/templates/blog.jsx
+++ b/src/templates/blog.jsx
@@ -47,7 +47,11 @@ const blog = (
         DATA.filter((blog) => {
           const searchRgx = new RegExp(escapeRegExp(searchQuery), "gi");
           const tagRgx = new RegExp(escapeRegExp(filterTag), "gi");
-          return blog.tags.match(tagRgx) && blog.title.match(searchRgx);
+          let matchedTag=[]
+          blog.tags.map(tag=>{
+            matchedTag.push(tag.match(tagRgx))
+          })
+          return matchedTag.toString().match(tagRgx) && blog.title.match(searchRgx);
         })
       );
       setIsShown(true);

--- a/src/templates/modulelist.jsx
+++ b/src/templates/modulelist.jsx
@@ -44,7 +44,13 @@ const modulelist = (
         DATA.filter((module) => {
           const searchRgx = new RegExp(escapeRegExp(searchQuery), "gi");
           const tagRgx = new RegExp(escapeRegExp(filterTag), "gi");
-          return module.tags.match(tagRgx) && module.title.match(searchRgx);
+          let matchedTag = [];
+          module.tags.map((tag) => {
+            if (tag != null) {
+              matchedTag.push(tag.match(tagRgx));
+            }
+          });
+          return matchedTag.toString().match(tagRgx) && module.title.match(searchRgx);
         })
       );
       setIsShown(true);

--- a/src/templates/modulelist.jsx
+++ b/src/templates/modulelist.jsx
@@ -14,7 +14,7 @@ const modulelist = (
   props
 ) => {
   const postEdges = data.allMarkdownRemark.edges;
-  const DATA = moduleList;
+  const moduleData = moduleList;
 
   const prefix = "/modules/";
   const isFirst = moduleCurrentPage === 1;
@@ -41,16 +41,15 @@ const modulelist = (
   useEffect(() => {
     if (searchQuery || filterTag) {
       setResults(
-        DATA.filter((module) => {
+        moduleData.filter((module) => {
           const searchRgx = new RegExp(escapeRegExp(searchQuery), "gi");
           const tagRgx = new RegExp(escapeRegExp(filterTag), "gi");
-          let matchedTag = [];
-          module.tags.map((tag) => {
-            if (tag != null) {
-              matchedTag.push(tag.match(tagRgx));
-            }
-          });
-          return matchedTag.toString().match(tagRgx) && module.title.match(searchRgx);
+          const matchedTag = module.tags
+            .filter((tag) => tag != null)
+            .map((t) => t.match(tagRgx));
+          return (
+            matchedTag.toString().match(tagRgx) && module.title.match(searchRgx)
+          );
         })
       );
       setIsShown(true);

--- a/src/templates/modules.jsx
+++ b/src/templates/modules.jsx
@@ -31,11 +31,13 @@ export default class ModuleTemplate extends React.Component {
             <GatsbyImage
               className={"post-cover"}
               image={post.cover.childImageSharp.gatsbyImageData}
-              
             />
-
             <h1>{post.title}</h1>
-            <PostTags tags={post.tags} type={"modules"} />
+            <div className="d-flex mt-2 ml-2">
+              {post.tags.map((tag) => {
+                return <PostTags tags={tag} type={"modules"} />;
+              })}
+            </div>
             <hr></hr>
             <div dangerouslySetInnerHTML={{ __html: postNode.html }} />
             <div className="post-meta">


### PR DESCRIPTION
This PR fixes the issue of tags before ModuleSite can only use a single tag now it can use multiple tags.
It introduces a new system to handle tags length that is greater than the two so that card structure can be maintained

Before:
tags: "Asset"

Now:
tags: ["Asset","Library"]

Screenshot:
![image](https://user-images.githubusercontent.com/49101492/124435737-e876de00-dd92-11eb-9b77-e374852de6a7.png)

Note:  You will not find the above card that is in the image it was generated during testing